### PR TITLE
allow listing of songs, fix typo

### DIFF
--- a/gmusicfs/gmusicfs.py
+++ b/gmusicfs/gmusicfs.py
@@ -373,7 +373,7 @@ class GMusicFS(LoggingMixIn, Operations):
         # TODO This could be moved into a Track class in the future
         st['st_mode'] = (S_IFREG | 0444)
         st['st_size'] = int(track['estimatedSize'])
-        if 'bytes' in t:
+        if 'bytes' in track:
             st['st_size'] = int(track['bytes'])
         st['st_ctime'] = st['st_mtime'] = st['st_atime'] = 0
         if 'creationTimestamp' in track:

--- a/gmusicfs/gmusicfs.py
+++ b/gmusicfs/gmusicfs.py
@@ -143,7 +143,7 @@ class Album(object):
         if get_size and self.library.true_file_size:
             for t in self.__tracks:
                 if not 'bytes' in t:
-                    r = urllib2.Request(self.get_track_stream(t)[0])
+                    r = urllib2.Request(self.get_track_stream(t))
                     r.get_method = lambda: 'HEAD'
                     u = urllib2.urlopen(r)
                     t['bytes'] = int(u.headers['Content-Length']) + ID3V1_TRAILER_SIZE

--- a/gmusicfs/gmusicfs.py
+++ b/gmusicfs/gmusicfs.py
@@ -83,7 +83,7 @@ class Playlist(object):
         """Return the track that corresponds to a filename from this playlist"""
         m = self.__filename_re.match(filename)
         if m:
-            tracknum = m.groups()[0]
+            tracknum = int(m.groups()[0])
             return self.__tracks[tracknum - 1]
         return None
 


### PR DESCRIPTION
fixes the following errors:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/fuse.py", line 479, in _wrapper
    return func(*args, **kwargs) or 0
  File "/usr/local/lib/python2.7/dist-packages/fuse.py", line 487, in getattr
    return self.fgetattr(path, buf, None)
  File "/usr/local/lib/python2.7/dist-packages/fuse.py", line 735, in fgetattr
    attrs = self.operations('getattr', path.decode(self.encoding), fh)
  File "/usr/local/lib/python2.7/dist-packages/fuse.py", line 948, in __call__
    ret = getattr(self, op)(path, *args)
  File "/usr/local/lib/python2.7/dist-packages/GMusicFS-0.1-py2.7.egg/gmusicfs/gmusicfs.py", line 433, in getattr
    track = playlist.get_track(parts['track'])
  File "/usr/local/lib/python2.7/dist-packages/GMusicFS-0.1-py2.7.egg/gmusicfs/gmusicfs.py", line 88, in get_track
    return self.__tracks[tracknum - 1]
TypeError: unsupported operand type(s) for -: 'unicode' and 'int'
```

and

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/fuse.py", line 479, in _wrapper
    return func(*args, **kwargs) or 0
  File "/usr/local/lib/python2.7/dist-packages/fuse.py", line 487, in getattr
    return self.fgetattr(path, buf, None)
  File "/usr/local/lib/python2.7/dist-packages/fuse.py", line 735, in fgetattr
    attrs = self.operations('getattr', path.decode(self.encoding), fh)
  File "/usr/local/lib/python2.7/dist-packages/fuse.py", line 948, in __call__
    ret = getattr(self, op)(path, *args)
  File "/usr/local/lib/python2.7/dist-packages/GMusicFS-0.1-py2.7.egg/gmusicfs/gmusicfs.py", line 416, in getattr
    st = self.track_to_stat(track)
  File "/usr/local/lib/python2.7/dist-packages/GMusicFS-0.1-py2.7.egg/gmusicfs/gmusicfs.py", line 376, in track_to_stat
    if 'bytes' in t:
NameError: global name 't' is not defined
```